### PR TITLE
Corrected regex for field that do not contain quotes

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -13,9 +13,8 @@ try:
     log_data = open(filename, "r")
 except:
     raise Exception("Invalid input file")
-
-pattern = re.compile(
-    '(\w+)(?:=)(?:"{1,2}([\w\-\.:\ =]+)"{1,3})|(\w+)=(?:([\w\-\.:\=]+))')  # Regex matches "field=value" or "field=""more words""" syntax
+# Regex matches "field=value" or "field=""more words""" syntax
+pattern = re.compile('(\w+)(?:=)((?:\"{1,2}([\w\-\.:\ =]+))\"|(\S*))')
 events = []  # List to hold individual event dicts
 
 for line in log_data:
@@ -36,7 +35,7 @@ for row in events:
 print("[+] Writing CSV")
 newfilename = (filename.split(
     "/")[len(filename.split("/"))-1].split('.')[0])+'.csv'  # Get base file name from logfile
-with open(newfilename, 'w') as fileh:
+with open(newfilename, 'w', newline='') as fileh:
     csvfile = csv.DictWriter(fileh, headers)  # Write headers
     csvfile.writeheader()
     for row in events:

--- a/convert.py
+++ b/convert.py
@@ -35,6 +35,7 @@ for row in events:
 print("[+] Writing CSV")
 newfilename = (filename.split(
     "/")[len(filename.split("/"))-1].split('.')[0])+'.csv'  # Get base file name from logfile
+#Added the newline option to prevent blank rows from outputting to CSV
 with open(newfilename, 'w', newline='') as fileh:
     csvfile = csv.DictWriter(fileh, headers)  # Write headers
     csvfile.writeheader()


### PR DESCRIPTION
I found that key fields were being omitted from the CSV the script generated. After comparing the raw log with the CSV, I found it was fields that did not contain quotation marks (dstip for example).

I have changed the regex to account for this and have tested it on quite a few lines from a raw log file. I wanted to create this issue in order to create a pull request with my changes.