### PR TITLE
Fix regex

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -59,7 +59,7 @@ except:
 
 # Regex matches "field=value" or "field=""more words""" syntax
 pattern = re.compile(
-    '(\w+)(?:=)(?:"{1,3}([\w\-\.:\ =]+)"{1,3})|(\w+)=(?:([\w\-\.:\=]+))'
+    r'(\w+)(?:=)(?:"{1,3}([^"]+)"{1,3})|(\w+)=(?:([^\s]+))'
 )
 events = []  # List to hold individual event dicts
 


### PR DESCRIPTION
- Explicitly set regex string as such to avoid syntax warnings and future syntax errors

-  Fix #13: Too narrow of a scope of possible characters, missed some of the fields. 